### PR TITLE
Refactored widget for Django 1.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ script.
 Usage
 -----
 
-Simply add ``IntlTelInputWidget`` to your form field.
+Simply add ``IntlTelInputWidget`` to your form field. It will add a visible text input field and a hidden input field.
 
 .. code:: python
 
@@ -47,8 +47,22 @@ With a standard form:
 .. code:: python
 
     class MyForm(forms.Form):
-        tel_number = forms.CharField(widget=IntlTelInputWidget())
+        tel_number = forms.CharField(widget=IntlTelInputWidget(
+            visible_input_attrs={
+                'size': '30',
+                'class': 'my-css-class',
+                ...
+            },
+            hidden_input_attrs={
+                'class': 'another-css-class',
+                ...
+            }
+        ))
         ...
+
+The two arguments ``visible_input_attrs`` and ``hidden_input_attrs`` can be used to add additional HTML 
+attributes to the visible text input field respectively to the hidden input field. 
+
 
 Form media
 ----------

--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,9 @@ jQuery.
 If you load jQuery in the head of your document, you needn't worry about
 this step - widget media will be inserted right after the field. If you
 want to keep all JS at the end of your document, you can still use the
-``{{ form.media.js }}`` tag to achieve that. In case you use `crispy-forms`_
-and in order to assure that ``init.js`` gets loaded after jQuery:
+``{{ form.media.js }}`` tag to achieve that. However, if you use `crispy-forms`_,
+you need to set ``include_media = False`` in order to assure that ``init.js``
+gets loaded **after** jQuery and consequently to avoid JS errors:
 
 .. code:: python
 
@@ -74,7 +75,7 @@ and in order to assure that ``init.js`` gets loaded after jQuery:
             ...
 
 If you use ``self.helper.include_media = False`` in your form, you
-further have to add ``{{ user_form.media.css }}`` to your template
+have to add ``{{ form.media.css }}`` to your template
 where this widget appears in order to load ``intlTelInput.css``.
 
 If you need to load all JS in the head, you can make the ``init.js`` script
@@ -95,70 +96,71 @@ Options
 -------
 
 The widget can be invoked with most keyword arguments which translate to the `options`_
-available in the jQuery plugin **intl-tel-input**.
+available in the jQuery plugin intl-tel-input.
 
-**allow_dropdown**
-Type: `Boolean` Default: `True`
+allow_dropdown
+  Type: `Boolean` Default: `True`
 
-Example usage:
+  Example usage:
 
-.. code:: python
+    .. code:: python
+    
+        class MyForm(forms.Form):
+                tel_number = forms.CharField(widget=IntlTelInputWidget(
+                    allow_dropdown=False,
+                ))
+                ...
 
-    class MyForm(forms.Form):
-            tel_number = forms.CharField(widget=IntlTelInputWidget(
-                allow_dropdown=False,
-            ))
-            ...
+auto_hide_dial_code
+  Type: `Boolean` Default: `True`
 
-**auto_hide_dial_code**
-Type: `Boolean` Default: `True`
+auto_placeholder
+  Type: `String` Default: `"polite"`
 
-**auto_placeholder**
-Type: `String` Default: `"polite"`
+custom_placeholder
+  This option is not implemented yet.
 
-**custom_placeholder**
-This option is not implemented yet.
+dropdown_container
+  Type: `String` Default: `""`
 
-**dropdown_container**
-Type: `String` Default: `""`
+exclude_countries
+  Type: `List` Default: `[]`
 
-**exclude_countries**
-Type: `List` Default: `[]`
+  Example usage:
 
-Example usage:
+    .. code:: python
+    
+        class MyForm(forms.Form):
+                tel_number = forms.CharField(widget=IntlTelInputWidget(
+                    exclude_countries=['at', 'de', 'ch'],
+                ))
+                ...
 
-.. code:: python
+format_on_display
+  Type: `Boolean` Default: `True`
 
-    class MyForm(forms.Form):
-            tel_number = forms.CharField(widget=IntlTelInputWidget(
-                exclude_countries=['at', 'de', 'ch'],
-            ))
-            ...
+auto_geo_ip
+  Type: `Boolean` Default: `False`
 
-**format_on_display**
-Type: `Boolean` Default: `True`
+  This option represents geoIpLookup. If set to `True`, the user's location is lookup up. 
+  In order to lookup the user's location, https://freegeoip.net/json/ is used.
 
-**auto_geo_ip**
-Type: `Boolean` Default: `False`
-This option represents geoIpLookup. If set to `True`, the user's location is lookup up.
-In order to lookup the user's location, https://freegeoip.net/json/ is used.
+initial_country
+  Type: `String` Default: `""`
 
-**initial_country**
-Type: `String` Default: `""`
+national_mode
+  Type: `Boolean` Default: `True`
 
-**national_mode**
-Type: `Boolean` Default: `True`
+placeholder_number_type
+  Type: `String` Default: `"MOBILE"`
 
-**placeholder_number_type**
-Type: `String` Default: `"MOBILE"`
+only_countries  
+  Type: `List` Default: `[]`  
 
-**only_countries**
-Type: `List` Default: `[]`
+preferred_countries
+  Type: `List` Default: `['us', 'gb']`
 
-**preferred_countries**
-Type: `List` Default: `['us', 'gb']`
-
-**separate_dial_code**
-Type: `Boolean` Default: `False`
+separate_dial_code
+  Type: `Boolean` Default: `False`
 
 .. _options: https://github.com/jackocnr/intl-tel-input/blob/master/README.md#options

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,7 @@ django-intl-tel-input
 A Django form widget based on the jQuery plugin `intl-tel-input`_.
 
 This is a new package, so it doesn't implement all the features of
-intl-tel-input. However, it has been stable in testing, so if you're
-still down...
+intl-tel-input. However, it has been stable in testing.
 
 Installation
 ------------
@@ -49,8 +48,7 @@ With a standard form:
 
     class MyForm(forms.Form):
         tel_number = forms.CharField(widget=IntlTelInputWidget())
-
-    ...
+        ...
 
 Form media
 ----------
@@ -63,8 +61,21 @@ jQuery.
 If you load jQuery in the head of your document, you needn't worry about
 this step - widget media will be inserted right after the field. If you
 want to keep all JS at the end of your document, you can still use the
-``{{ form.media.js }}`` tag to achieve that. Just make sure it always comes
-after the form field.
+``{{ form.media.js }}`` tag to achieve that. In case you use `crispy-forms`_
+and in order to assure that ``init.js`` gets loaded after jQuery:
+
+.. code:: python
+
+    class MyForm(forms.Form):
+        def __init__(self, *args, **kwargs):
+            ...
+            self.helper = FormHelper()
+            self.helper.include_media = False
+            ...
+
+If you use ``self.helper.include_media = False`` in your form, you
+further have to add ``{{ user_form.media.css }}`` to your template
+where this widget appears in order to load ``intlTelInput.css``.
 
 If you need to load all JS in the head, you can make the ``init.js`` script
 wait for the document to be ready with the following snippet.
@@ -78,13 +89,76 @@ wait for the document to be ready with the following snippet.
 All this assumes your form context variable is called ``form``.
 
 .. _intl-tel-input: https://github.com/jackocnr/intl-tel-input
+.. _crispy-forms: https://github.com/django-crispy-forms/django-crispy-forms
 
 Options
 -------
 
-The widget can be invoked with keyword arguments which translate to the options
-available in intl-tel-input.
+The widget can be invoked with most keyword arguments which translate to the `options`_
+available in the jQuery plugin **intl-tel-input**.
 
-allow_dropdown
-  Shows the country dropdown.
-  Default: True
+**allow_dropdown**
+Type: `Boolean` Default: `True`
+
+Example usage:
+
+.. code:: python
+
+    class MyForm(forms.Form):
+            tel_number = forms.CharField(widget=IntlTelInputWidget(
+                allow_dropdown=False,
+            ))
+            ...
+
+**auto_hide_dial_code**
+Type: `Boolean` Default: `True`
+
+**auto_placeholder**
+Type: `String` Default: `"polite"`
+
+**custom_placeholder**
+This option is not implemented yet.
+
+**dropdown_container**
+Type: `String` Default: `""`
+
+**exclude_countries**
+Type: `List` Default: `[]`
+
+Example usage:
+
+.. code:: python
+
+    class MyForm(forms.Form):
+            tel_number = forms.CharField(widget=IntlTelInputWidget(
+                exclude_countries=['at', 'de', 'ch'],
+            ))
+            ...
+
+**format_on_display**
+Type: `Boolean` Default: `True`
+
+**auto_geo_ip**
+Type: `Boolean` Default: `False`
+This option represents geoIpLookup. If set to `True`, the user's location is lookup up.
+In order to lookup the user's location, https://freegeoip.net/json/ is used.
+
+**initial_country**
+Type: `String` Default: `""`
+
+**national_mode**
+Type: `Boolean` Default: `True`
+
+**placeholder_number_type**
+Type: `String` Default: `"MOBILE"`
+
+**only_countries**
+Type: `List` Default: `[]`
+
+**preferred_countries**
+Type: `List` Default: `['us', 'gb']`
+
+**separate_dial_code**
+Type: `Boolean` Default: `False`
+
+.. _options: https://github.com/jackocnr/intl-tel-input/blob/master/README.md#options

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ The widget can be invoked with most keyword arguments which translate to the `op
 available in the jQuery plugin intl-tel-input.
 
 allow_dropdown
-  Type: `Boolean` Default: `True`
+  Type: ``Boolean`` Default: ``True``
 
   Example usage:
 
@@ -112,19 +112,19 @@ allow_dropdown
                 ...
 
 auto_hide_dial_code
-  Type: `Boolean` Default: `True`
+  Type: ``Boolean`` Default: ``True``
 
 auto_placeholder
-  Type: `String` Default: `"polite"`
+  Type: ``String`` Default: ``"polite"``
 
 custom_placeholder
   This option is not implemented yet.
 
 dropdown_container
-  Type: `String` Default: `""`
+  Type: ``String`` Default: ``""``
 
 exclude_countries
-  Type: `List` Default: `[]`
+  Type: ``List`` Default: ``[]``
 
   Example usage:
 
@@ -137,30 +137,30 @@ exclude_countries
                 ...
 
 format_on_display
-  Type: `Boolean` Default: `True`
+  Type: ``Boolean`` Default: ``True``
 
 auto_geo_ip
-  Type: `Boolean` Default: `False`
+  Type: ``Boolean`` Default: ``False``
 
-  This option represents geoIpLookup. If set to `True`, the user's location is lookup up. 
+  This option represents geoIpLookup. If set to ``True``, the user's location is lookup up. 
   In order to lookup the user's location, https://freegeoip.net/json/ is used.
 
 initial_country
-  Type: `String` Default: `""`
+  Type: ``String`` Default: ``""``
 
 national_mode
-  Type: `Boolean` Default: `True`
+  Type: ``Boolean`` Default: ``True``
 
 placeholder_number_type
-  Type: `String` Default: `"MOBILE"`
+  Type: ``String`` Default: ``"MOBILE"``
 
 only_countries  
-  Type: `List` Default: `[]`  
+  Type: ``List`` Default: ``[]``  
 
 preferred_countries
-  Type: `List` Default: `['us', 'gb']`
+  Type: ``List`` Default: ``['us', 'gb']``
 
 separate_dial_code
-  Type: `Boolean` Default: `False`
+  Type: ``Boolean`` Default: ``False``
 
 .. _options: https://github.com/jackocnr/intl-tel-input/blob/master/README.md#options

--- a/intl_tel_input/static/intl_tel_input/init.js
+++ b/intl_tel_input/static/intl_tel_input/init.js
@@ -1,5 +1,5 @@
-(function($) {
-  var $el, $realInput, options, $form, data, defaultCode,
+;(function($) {
+  var $el, $realInput, options, $form, data, initialCountry, autoGeoIp, autoHideDialCode,
       cssClass = '.js-intl-tel-input',
       hiddenCssClass = '.js-intl-tel-input-hidden',
       forms = [],
@@ -9,21 +9,35 @@
     $el = $(el);
     $realInput = $el.siblings(hiddenCssClass);
     data = $el.data();
-    defaultCode = data.defaultCode !== undefined ? data.defaultCode : 'us';
+    initialCountry = data.initialCountry !== undefined ? data.initialCountry : '';
+    autoGeoIp = data.autoGeoIp !== undefined ? true : false;
+    autoHideDialCode = data.autoHideDialCode !== undefined ? true : false;
+
     options = {
-      initialCountry: data.autoGeoIp ? 'auto' : data.defaultCode,
+      allowDropdown: data.allowDropdown !== undefined ? true : false,
+      autoHideDialCode: autoHideDialCode,
+      autoPlaceholder: data.autoPlaceholder !== undefined ? data.autoPlaceholder : 'polite',
+      dropdownContainer: data.dropdownContainer !== undefined ? data.dropdownContainer : '',
+      excludeCountries: data.excludeCountries !== undefined ? data.excludeCountries : [],
+      formatOnDisplay: data.formatOnDisplay !== undefined ? true : false,
       geoIpLookup: function(callback) {
-        if (data.autoGeoIp) {
+        if (autoGeoIp) {
           $.get('https://freegeoip.net/json/', function() {}, "jsonp").done(function(resp) {
             var countryCode = (resp && resp.country_code) ? resp.country_code : "";
+            console.info('Detected country: ' + countryCode);
             callback(countryCode);
           }).fail(function(jqXHR) {
             console.warn('GeoIP Error: ' + jqXHR.status);
-            callback(defaultCode);
+            callback(initialCountry);
           });
         }
       },
-      allowDropdown: data.allowDropdown !== undefined ? true : false
+      initialCountry: autoGeoIp ? 'auto' : initialCountry,
+      nationalMode: data.nationalMode !== undefined ? true : false,
+      placeholderNumberType: data.placeholderNumberType !== undefined ? data.placeholderNumberType : 'MOBILE',
+      onlyCountries: data.onlyCountries !== undefined ? data.onlyCountries : [],
+      preferredCountries: data.preferredCountries !== undefined ? data.preferredCountries : ['us', 'gb'],
+      separateDialCode: data.separateDialCode !== undefined ? true : false
     };
 
     options.utilsScript = 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/11.1.1/js/utils.js';

--- a/intl_tel_input/static/intl_tel_input/init.js
+++ b/intl_tel_input/static/intl_tel_input/init.js
@@ -1,19 +1,20 @@
 (function($) {
   var $el, $realInput, options, $form, data, defaultCode,
-      cssClass = '.intl-tel-input',
+      cssClass = '.js-intl-tel-input',
+      hiddenCssClass = '.js-intl-tel-input-hidden',
       forms = [],
       inputs = $(cssClass);
 
   inputs.each(function(i, el) {
     $el = $(el);
-    $realInput = $el.prev();
+    $realInput = $el.siblings(hiddenCssClass);
     data = $el.data();
     defaultCode = data.defaultCode !== undefined ? data.defaultCode : 'us';
     options = {
       initialCountry: data.autoGeoIp ? 'auto' : data.defaultCode,
       geoIpLookup: function(callback) {
         if (data.autoGeoIp) {
-          $.get('//freegeoip.net/json/', function() {}, "jsonp").done(function(resp) {
+          $.get('https://freegeoip.net/json/', function() {}, "jsonp").done(function(resp) {
             var countryCode = (resp && resp.country_code) ? resp.country_code : "";
             callback(countryCode);
           }).fail(function(jqXHR) {
@@ -25,7 +26,7 @@
       allowDropdown: data.allowDropdown !== undefined ? true : false
     };
 
-    options.utilsScript = 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/9.0.1/js/utils.js';
+    options.utilsScript = 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/11.1.1/js/utils.js';
 
     $el.intlTelInput(options)
     .done(function() {

--- a/intl_tel_input/static/intl_tel_input/init.js
+++ b/intl_tel_input/static/intl_tel_input/init.js
@@ -1,13 +1,13 @@
 ;(function($) {
-  var $el, $realInput, options, $form, data, initialCountry, autoGeoIp, autoHideDialCode,
+  var options, $form, data, initialCountry, autoGeoIp, autoHideDialCode,
       cssClass = '.js-intl-tel-input',
       hiddenCssClass = '.js-intl-tel-input-hidden',
       forms = [],
       inputs = $(cssClass);
 
   inputs.each(function(i, el) {
-    $el = $(el);
-    $realInput = $el.siblings(hiddenCssClass);
+    var $el = $(el);
+    var $realInput = $el.siblings(hiddenCssClass);
     data = $el.data();
     initialCountry = data.initialCountry !== undefined ? data.initialCountry : '';
     autoGeoIp = data.autoGeoIp !== undefined ? true : false;

--- a/intl_tel_input/widgets.py
+++ b/intl_tel_input/widgets.py
@@ -11,11 +11,7 @@ class IntlTelInput(forms.TextInput):
         Initialize visible International Telephone Input field in which users enter their phone number.
 
         :param attrs: Dictionary of HTML attributes, e.g. {'size': '50', 'class': 'my-css-class'}
-        :param kwargs: intl-tel-input options according to
-            https://github.com/jackocnr/intl-tel-input/blob/master/README.md#options.
-            All options are added as data attributes (e.g. data-auto-placeholder="polite") to this input field.
-
-            Be aware that option names must be given in snake_case. They will be translated to camelCase in the init.js.
+        :param kwargs: intl-tel-input options (see :class:~.IntlTelInputWidget`)
         """
         my_attrs = {'size': '30', 'class': 'js-intl-tel-input'}
 
@@ -77,6 +73,17 @@ class IntlTelInputWidget(forms.MultiWidget):
         )
 
     def __init__(self, visible_input_attrs=None, hidden_input_attrs=None, **kwargs):
+        """
+        Initialize MultiWidget comprising a TextInput and a HiddenInput widget.
+
+        :param visible_input_attrs: Dictionary with HTML attributes of the TextInput widget.
+        :param hidden_input_attrs: Dictionary with HTML attributes of the HiddenInput widget.
+        :param kwargs: intl-tel-input options according to
+            https://github.com/jackocnr/intl-tel-input/blob/master/README.md#options.
+            All options are added as data attributes (e.g. data-auto-placeholder="polite") to this input field.
+
+            Be aware that option names must be given in snake_case. They will be translated to camelCase in the init.js.
+        """
         _widgets = (
             IntlTelInput(attrs=visible_input_attrs, **kwargs),
             IntlTelInputHidden(attrs=hidden_input_attrs),

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-intl-tel-input',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',
@@ -21,7 +21,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -33,4 +33,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    install_requires=['Django>=1.11']
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-intl-tel-input',
-    version='0.1.3',
+    version='0.2.0',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Since form widget rendering was changed in 1.11 (see [Django 1.11 release notes](https://docs.djangoproject.com/en/1.11/releases/1.11/#template-based-widget-rendering)), I refactored the widget and extend the MultiWidget class instead of the Widget class. I use a TextInput widget and a HiddenInput widget in order to recreate the example shown [here](https://intl-tel-input.com/node_modules/intl-tel-input/examples/gen/hidden-input.html).

Furthermore, I added nearly all options except from _customPlaceholder_. 

I wasn't quite sure if should take care of backward compatibility, but since I am quite a newbee in Django, I merely focused on a working refactored widget.